### PR TITLE
Store token result in terraform state

### DIFF
--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -74,8 +74,9 @@ func ResourceAuthorization() *schema.Resource {
 				Computed: true,
 			},
 			"token": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}
@@ -101,6 +102,12 @@ func resourceAuthorizationCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error creating authorization: %e", err)
 	}
 	d.SetId(*result.Id)
+	// token is only ever received once, so we must set it from this response
+	// and can not read it later
+	err = d.Set("token", *result.Token)
+	if err != nil {
+		return err
+	}
 	return resourceAuthorizationRead(d, meta)
 }
 
@@ -137,9 +144,11 @@ func resourceAuthorizationRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = d.Set("token", authorizations.Token)
-	if err != nil {
-		return err
+	if *authorizations.Token != "redacted" {
+		err = d.Set("token", authorizations.Token)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
InfluxDB tokens are only retrievable once, in the initial response from the POST. 
Any further attempt to retrieve them returns the result `redacted` on the API.

The `authorization` class was only extracting the ID from the initial response, and then re-requesting all further details. This means that the token was lost.

Instead, extract the token from the initial POST response, save it to the state. If any further updates happen to the `authorization`, check if the response is the literal string `redacted`, and ignore it if so.

Also mark the `authorization.token` as `Sensitive` in the schema, so it's not accidentally leakable from terraform.